### PR TITLE
Improve SEO metadata and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
     <title>NaturaGreen - Plantacja Choinek | Naturalne choinki prosto z plantacji</title>
     <meta name="description" content="Najwyższej jakości naturalne choinki świąteczne z rodzinnej plantacji. Świerk, jodła i inne odmiany choinek hodowane z poszanowaniem środowiska." />
     <meta name="author" content="NaturaGreen" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://plantacjasoldany.pl/" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
 
     <meta property="og:title" content="NaturaGreen - Plantacja Choinek" />
     <meta property="og:description" content="Najwyższej jakości naturalne choinki świąteczne z rodzinnej plantacji." />
@@ -24,7 +27,7 @@
   <body>
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
+    <script src="https://cdn.gpteng.co/gptengineer.js" type="module" defer></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,4 @@ Allow: /
 
 User-agent: *
 Allow: /
+Sitemap: https://plantacjasoldany.pl/sitemap.xml

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -18,7 +18,7 @@ const Contact = () => {
           <div className="mt-8 space-y-5">
             <div className="flex items-start gap-4">
               <div className="bg-forest-100 p-3 rounded-full text-forest-600">
-                <MapPin size={20} />
+                <MapPin size={20} aria-hidden="true" />
               </div>
               <div>
                 <h3 className="font-medium text-forest-800 text-lg">Adres plantacji</h3>
@@ -32,7 +32,7 @@ const Contact = () => {
             
             <div className="flex items-start gap-4">
               <div className="bg-forest-100 p-3 rounded-full text-forest-600">
-                <Phone size={20} />
+                <Phone size={20} aria-hidden="true" />
               </div>
               <div>
                 <h3 className="font-medium text-forest-800 text-lg">Telefon</h3>
@@ -44,7 +44,7 @@ const Contact = () => {
             
             <div className="flex items-start gap-4">
               <div className="bg-forest-100 p-3 rounded-full text-forest-600">
-                <Mail size={20} />
+                <Mail size={20} aria-hidden="true" />
               </div>
               <div>
                 <h3 className="font-medium text-forest-800 text-lg">Email</h3>
@@ -56,7 +56,7 @@ const Contact = () => {
             
             <div className="flex items-start gap-4">
               <div className="bg-forest-100 p-3 rounded-full text-forest-600">
-                <Clock size={20} />
+                <Clock size={20} aria-hidden="true" />
               </div>
               <div>
                 <h3 className="font-medium text-forest-800 text-lg">Godziny otwarcia</h3>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -42,9 +42,10 @@ const CookieBanner = () => {
               </Button>
             </div>
           </div>
-          <button 
+          <button
             onClick={closeBanner}
             className="text-forest-600 hover:text-forest-800 transition-colors"
+            aria-label="Zamknij baner cookies"
           >
             <X size={16} />
           </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,11 +17,23 @@ const Footer = () => {
               Rodzinna plantacja choinek z tradycjami. Oferujemy najwyższej jakości świerki pospolite, srebrne oraz w donicach. Hodowane w Mazurskiej miejscowości Sołdany koło Giżycka.
             </p>
             <div className="flex space-x-4">
-              <a href="https://www.facebook.com/plantacjasoldany/?locale=pl_PL" className="text-white hover:text-forest-400 transition-colors">
-                <Facebook size={20} />
+              <a
+                href="https://www.facebook.com/plantacjasoldany/?locale=pl_PL"
+                className="text-white hover:text-forest-400 transition-colors"
+                aria-label="Facebook"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Facebook size={20} aria-hidden="true" />
               </a>
-              <a href="https://www.instagram.com/plantacja.soldany/?hl=en-gb" className="text-white hover:text-forest-400 transition-colors">
-                <Instagram size={20} />
+              <a
+                href="https://www.instagram.com/plantacja.soldany/?hl=en-gb"
+                className="text-white hover:text-forest-400 transition-colors"
+                aria-label="Instagram"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Instagram size={20} aria-hidden="true" />
               </a>
             </div>
           </div>
@@ -32,8 +44,12 @@ const Footer = () => {
             <ul className="space-y-3">
               {['Strona główna', 'Odmiany choinek', 'O naszej plantacji', 'Sezony i dostępność', 'Kontakt'].map((link) => (
                 <li key={link}>
-                  <a 
-                    href={link.toLowerCase().replace(/\s+/g, '-') === 'strona-główna' ? '/' : `/#${link.toLowerCase().replace(/\s+/g, '-')}`}
+                  <a
+                    href={
+                      link.toLowerCase().replace(/\s+/g, '-') === 'strona-główna'
+                        ? '/'
+                        : `#${link.toLowerCase().replace(/\s+/g, '-')}`
+                    }
                     className="text-forest-200 hover:text-white transition-colors"
                   >
                     {link}
@@ -48,7 +64,7 @@ const Footer = () => {
             <h4 className="text-xl font-semibold text-white mb-6 font-serif">Kontakt</h4>
             <ul className="space-y-4">
               <li className="flex items-start gap-3">
-                <MapPin size={18} className="text-forest-400 mt-1" />
+                <MapPin size={18} className="text-forest-400 mt-1" aria-hidden="true" />
                 <span className="text-forest-200">
                   Sołdany 28<br />
                   11-500 Sołdany<br />
@@ -56,11 +72,11 @@ const Footer = () => {
                 </span>
               </li>
               <li className="flex items-center gap-3">
-                <Phone size={18} className="text-forest-400" />
+                <Phone size={18} className="text-forest-400" aria-hidden="true" />
                 <span className="text-forest-200">+48 796 214 778</span>
               </li>
               <li className="flex items-center gap-3">
-                <Mail size={18} className="text-forest-400" />
+                <Mail size={18} className="text-forest-400" aria-hidden="true" />
                 <span className="text-forest-200">plantacjasoldany@gmail.com</span>
               </li>
             </ul>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -15,7 +15,7 @@ const Hero = () => {
       {/* Content */}
       <div className="container mx-auto px-6 md:px-12 relative z-20 text-center">
         <h1 className="text-4xl md:text-5xl lg:text-7xl font-bold text-white opacity-0 animate-fade-in max-w-4xl mx-auto leading-tight">Plantacja Choinek Soldany</h1>
-        <p className="mt-6 text-xl md:text-2xl text-white/90 opacity-0 animate-fade-in-delay-1 max-w-2xl mx-auto">Tradycja, jakość i szacunek do natury od ponad 15 lat   </p>
+          <p className="mt-6 text-xl md:text-2xl text-white/90 opacity-0 animate-fade-in-delay-1 max-w-2xl mx-auto">Tradycja, jakość i szacunek do natury od ponad 15 lat</p>
         <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center opacity-0 animate-fade-in-delay-2">
           <a href="#odmiany" className="btn-primary">
             Odkryj nasze odmiany
@@ -27,7 +27,11 @@ const Hero = () => {
       </div>
       
       {/* Scroll Down Indicator */}
-      <a href="#odmiany" className="absolute bottom-10 left-1/2 transform -translate-x-1/2 z-20 text-white opacity-0 animate-fade-in-delay-3 animate-float">
+      <a
+        href="#odmiany"
+        aria-label="Przejdź do sekcji odmiany"
+        className="absolute bottom-10 left-1/2 transform -translate-x-1/2 z-20 text-white opacity-0 animate-fade-in-delay-3 animate-float"
+      >
         <ArrowDownCircle size={36} className="opacity-70 hover:opacity-100 transition-opacity" />
       </a>
     </section>;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,9 +27,13 @@ const Navbar = () => {
           {/* Desktop Menu */}
           <div className="hidden md:flex space-x-8">
             {['Strona główna', 'Odmiany', 'O nas', 'Drzewka', 'Sezony', 'Kontakt'].map((item) => (
-              <a 
-                key={item} 
-                href={`/${item.toLowerCase().replace(' ', '-') === 'strona-główna' ? '' : `#${item.toLowerCase().replace(' ', '-')}`}`}
+              <a
+                key={item}
+                href={
+                  item.toLowerCase().replace(' ', '-') === 'strona-główna'
+                    ? '/'
+                    : `#${item.toLowerCase().replace(' ', '-')}`
+                }
                 className="text-forest-700 hover:text-forest-500 transition-colors font-bold"
               >
                 {item}
@@ -38,9 +42,10 @@ const Navbar = () => {
           </div>
           
           {/* Mobile Menu Button */}
-          <button 
+          <button
             className="md:hidden text-forest-700"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-label={mobileMenuOpen ? 'Zamknij menu' : 'Otwórz menu'}
           >
             {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
           </button>
@@ -50,12 +55,16 @@ const Navbar = () => {
         {mobileMenuOpen && (
           <div className="md:hidden bg-gray-200/40 backdrop-blur-sm rounded-3xl shadow-md mt-2 px-4 py-3">
             {['Strona główna', 'Odmiany', 'O nas', 'Drzewka', 'Sezony', 'Kontakt'].map((item) => (
-              <a 
-                key={item} 
-                href={`/${item.toLowerCase().replace(' ', '-') === 'strona-główna' ? '' : `#${item.toLowerCase().replace(' ', '-')}`}`}
-                className="block text-forest-700 hover:text-forest-500 transition-colors font-bold py-2 px-2"
-                onClick={() => setMobileMenuOpen(false)}
-              >
+                <a
+                  key={item}
+                  href={
+                    item.toLowerCase().replace(' ', '-') === 'strona-główna'
+                      ? '/'
+                      : `#${item.toLowerCase().replace(' ', '-')}`
+                  }
+                  className="block text-forest-700 hover:text-forest-500 transition-colors font-bold py-2 px-2"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
                 {item}
               </a>
             ))}


### PR DESCRIPTION
## Summary
- add robots, canonical, and sitemap tags for better SEO
- correct navigation links and aria labels for more accessible menu and footer
- mark decorative icons as hidden and defer external script loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden; An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_68af5c3c85d4832889d9ccea2ab95403